### PR TITLE
Changing Using to receive concrete generic IDisposable

### DIFF
--- a/FunctionalProgramming/Basics/BasicFunctions.cs
+++ b/FunctionalProgramming/Basics/BasicFunctions.cs
@@ -88,7 +88,7 @@ namespace FunctionalProgramming.Basics
         /// <param name="source">An 'IDisposable' that will be disposed after body is invoked</param>
         /// <param name="body">Statements to execute before disposing of source</param>
         /// <returns>A value that represents an effectual computation that is only useful for its side-effects</returns>
-        public static Io<Unit> Using(Func<IDisposable> source, Action<IDisposable> body)
+        public static Io<Unit> Using<T>(Func<T> source, Action<T> body) where T : IDisposable
         {
             return Io.Apply(() =>
             {
@@ -96,6 +96,7 @@ namespace FunctionalProgramming.Basics
                 {
                     body(resource);
                 }
+
                 return Unit.Only;
             });
         }


### PR DESCRIPTION
Modifying Using given that the current implementation requires casting 
to concrete IDisposable in order to be used.

Take as an example the following scenario:

```C#
/* Current Implementation */
const string FileName = "file.dat";

BasicFunctions.Using(
  source: () => new StreamReader(FileName),
  body: f => f.ReadLine()); // Cannot resolve symbol 'ReadLine'

BasicFunctions.Using(
  source: () => new StreamReader(FileName),
  body: f => ((StreamReader)f).ReadLine()); // Works, but not prefered.

/* With Change */
BasicFunctions.Using(
  source: () => new StreamReader(FileName),
  body: f => f.ReadLine()); // Works like a charm.
```